### PR TITLE
feat: rewrite UI with shadcn/ui

### DIFF
--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -1,21 +1,30 @@
 import React from "react";
+import { Github } from "lucide-react";
+
 const Footer = () => {
   return (
-    <footer className="container p-4 bg-white md:flex md:items-center md:justify-between md:p-6 dark:bg-gray-800 transition-colors duration-200">
-      <span className="text-sm text-gray-500 sm:text-center dark:text-gray-400">
-        © 2023{" "}
-        <a href="https://github.com/jianan1104/" className="hover:underline">
-          jianan1104
-        </a>
-        . All Rights Reserved.
-      </span>
-      <ul className="flex flex-wrap items-center mt-3 text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
-        <li>
-          <a href="https://github.com/jianan1104/vagrantfile-generator" className="mr-4 hover:underline md:mr-6 ">
-            Github
+    <footer className="border-t py-6 mt-8">
+      <div className="container flex flex-col items-center justify-between gap-4 md:flex-row">
+        <p className="text-sm text-muted-foreground">
+          &copy; {new Date().getFullYear()}{" "}
+          <a
+            href="https://github.com/jianan1104/"
+            className="font-medium underline underline-offset-4 hover:text-foreground"
+          >
+            jianan1104
           </a>
-        </li>
-      </ul>
+          . All rights reserved.
+        </p>
+        <a
+          href="https://github.com/jianan1104/vagrantfile-generator"
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Github className="h-4 w-4" />
+          GitHub
+        </a>
+      </div>
     </footer>
   );
 };

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -3,26 +3,26 @@ import { Github } from "lucide-react";
 
 const Footer = () => {
   return (
-    <footer className="border-t py-6 mt-8">
+    <footer className="border-t border-border/50 py-8 mt-12">
       <div className="container flex flex-col items-center justify-between gap-4 md:flex-row">
-        <p className="text-sm text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           &copy; {new Date().getFullYear()}{" "}
           <a
             href="https://github.com/jianan1104/"
-            className="font-medium underline underline-offset-4 hover:text-foreground"
+            className="font-medium hover:text-foreground transition-colors"
           >
             jianan1104
           </a>
-          . All rights reserved.
+          . Built with care for the DevOps community.
         </p>
         <a
           href="https://github.com/jianan1104/vagrantfile-generator"
-          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
           target="_blank"
           rel="noreferrer"
         >
-          <Github className="h-4 w-4" />
-          GitHub
+          <Github className="h-3.5 w-3.5" />
+          Source on GitHub
         </a>
       </div>
     </footer>

--- a/components/Navbar/index.jsx
+++ b/components/Navbar/index.jsx
@@ -1,28 +1,35 @@
 import React from "react";
 import GitHubButton from "react-github-btn";
 import ThemeToggle from "../ThemeToggle";
-import { Separator } from "../../src/components/ui/separator";
+import { Badge } from "../../src/components/ui/badge";
 
 const Navbar = () => {
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-14 items-center justify-between">
+    <header className="sticky top-0 z-50 w-full glass-strong">
+      <div className="container flex h-16 items-center justify-between">
         <a
           href="https://vagrantfile-generator.vercel.app/"
-          className="flex items-center gap-2"
+          className="flex items-center gap-3 group"
         >
-          <img
-            src="images/vagrant-icon.png"
-            className="h-7"
-            alt="Vagrant Logo"
-          />
-          <span className="font-bold text-lg tracking-tight">
-            Vagrantfile Generator
-          </span>
+          <div className="relative">
+            <img
+              src="images/vagrant-icon.png"
+              className="h-8 transition-transform duration-200 group-hover:scale-110"
+              alt="Vagrant Logo"
+            />
+          </div>
+          <div className="flex items-center gap-2.5">
+            <span className="font-bold text-lg tracking-tight">
+              Vagrantfile Generator
+            </span>
+            <Badge variant="secondary" className="text-[10px] px-2 py-0.5 font-mono">
+              v2.0
+            </Badge>
+          </div>
         </a>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           <ThemeToggle />
-          <Separator orientation="vertical" className="h-6" />
+          <div className="h-5 w-px bg-border" />
           <GitHubButton
             href="https://github.com/jianan1104/vagrantfile-generator"
             data-icon="octicon-star"

--- a/components/Navbar/index.jsx
+++ b/components/Navbar/index.jsx
@@ -1,31 +1,40 @@
 import React from "react";
 import GitHubButton from "react-github-btn";
 import ThemeToggle from "../ThemeToggle";
+import { Separator } from "../../src/components/ui/separator";
 
 const Navbar = () => {
   return (
-    <nav className="bg-white px-2 sm:px-4 py-2.5 dark:bg-gray-900 w-full z-20 top-0 left-0 border-b border-gray-200 dark:border-gray-600 transition-colors duration-200">
-      <div className="container flex flex-wrap items-center justify-between mx-auto">
-        <a href="https://vagrantfile-generator.vercel.app/" className="flex items-center">
-          <img src="images/vagrant-icon.png" className="h-6 mr-3 sm:h-10" alt="Vagrant Logo" />
-          <span className="self-center text-xl font-semibold whitespace-nowrap dark:text-white">
-            VagrantFile Generator
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="container flex h-14 items-center justify-between">
+        <a
+          href="https://vagrantfile-generator.vercel.app/"
+          className="flex items-center gap-2"
+        >
+          <img
+            src="images/vagrant-icon.png"
+            className="h-7"
+            alt="Vagrant Logo"
+          />
+          <span className="font-bold text-lg tracking-tight">
+            Vagrantfile Generator
           </span>
         </a>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           <ThemeToggle />
+          <Separator orientation="vertical" className="h-6" />
           <GitHubButton
             href="https://github.com/jianan1104/vagrantfile-generator"
             data-icon="octicon-star"
             data-size="large"
             data-show-count="true"
-            aria-label="Star google/vagrantfile-generator on GitHub"
+            aria-label="Star jianan1104/vagrantfile-generator on GitHub"
           >
             Star
           </GitHubButton>
         </div>
       </div>
-    </nav>
+    </header>
   );
 };
 

--- a/components/ProviderSelect/index.jsx
+++ b/components/ProviderSelect/index.jsx
@@ -11,37 +11,45 @@ const ProviderSelect = ({
   selectedGroup,
 }) => {
   return (
-    <div className="space-y-3 mb-6">
-      <Label htmlFor="provider">Provider</Label>
-
-      <div className="flex gap-2">
-        <Select
-          id="virtualization-group"
-          onChange={handleGroupChange}
-          value={selectedGroup.name}
-          className="w-[200px] shrink-0"
-        >
-          {virtualizationGroups.map((group) => (
-            <option key={group.id} value={group.name}>
-              {group.name}
-            </option>
-          ))}
-        </Select>
-        <Select
-          id="groups"
-          name="provider"
-          value={formData.provider}
-          onChange={handleInputChange}
-        >
-          {selectedGroup.items.map((provider, idx) => (
-            <option key={idx} value={provider}>
-              {provider}
-            </option>
-          ))}
-        </Select>
+    <div className="space-y-4">
+      <div className="flex gap-3">
+        <div className="space-y-2 flex-shrink-0">
+          <Label htmlFor="virtualization-group" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Category
+          </Label>
+          <Select
+            id="virtualization-group"
+            onChange={handleGroupChange}
+            value={selectedGroup.name}
+            className="w-[180px]"
+          >
+            {virtualizationGroups.map((group) => (
+              <option key={group.id} value={group.name}>
+                {group.name}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="space-y-2 flex-1">
+          <Label htmlFor="groups" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Provider
+          </Label>
+          <Select
+            id="groups"
+            name="provider"
+            value={formData.provider}
+            onChange={handleInputChange}
+          >
+            {selectedGroup.items.map((provider, idx) => (
+              <option key={idx} value={provider}>
+                {provider}
+              </option>
+            ))}
+          </Select>
+        </div>
       </div>
 
-      <ul className="grid w-full gap-4 grid-cols-2 md:grid-cols-4 lg:grid-cols-5">
+      <ul className="grid w-full gap-3 grid-cols-2 md:grid-cols-4 lg:grid-cols-5">
         {providers.map((provider) => (
           <RadioCard
             key={provider.id}

--- a/components/ProviderSelect/index.jsx
+++ b/components/ProviderSelect/index.jsx
@@ -1,53 +1,47 @@
-import React from 'react';
-import RadioCard from '../RadioCard';
-import { providers, virtualizationGroups } from '../constants';
+import React from "react";
+import RadioCard from "../RadioCard";
+import { providers, virtualizationGroups } from "../constants";
+import { Label } from "../../src/components/ui/label";
+import { Select } from "../../src/components/ui/select";
 
-const ProviderSelect = ({ 
-  formData, 
-  handleInputChange, 
-  handleGroupChange, 
-  selectedGroup 
+const ProviderSelect = ({
+  formData,
+  handleInputChange,
+  handleGroupChange,
+  selectedGroup,
 }) => {
   return (
-    <div className="mb-4">
-      <label
-        className="block text-gray-700 dark:text-gray-200 font-bold mb-2"
-        htmlFor="provider"
-      >
-        Provider
-      </label>
+    <div className="space-y-3 mb-6">
+      <Label htmlFor="provider">Provider</Label>
 
-      <div className="flex mb-2">
-        <select
-          id="countries"
+      <div className="flex gap-2">
+        <Select
+          id="virtualization-group"
           onChange={handleGroupChange}
           value={selectedGroup.name}
-          className="flex-shrink-0 z-10 inline-flex items-center py-2.5 px-4 text-sm font-medium text-center text-gray-500 bg-gray-100 border border-gray-300 rounded-l-lg hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:focus:ring-gray-700 dark:text-white dark:border-gray-600"
+          className="w-[200px] shrink-0"
         >
           {virtualizationGroups.map((group) => (
             <option key={group.id} value={group.name}>
               {group.name}
             </option>
           ))}
-        </select>
-        <label htmlFor="groups" className="sr-only">
-          Choose a provider
-        </label>
-        <select
+        </Select>
+        <Select
           id="groups"
           name="provider"
           value={formData.provider}
           onChange={handleInputChange}
-          className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-r-lg border-l-gray-100 dark:border-l-gray-700 border-l-2 focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
         >
           {selectedGroup.items.map((provider, idx) => (
             <option key={idx} value={provider}>
               {provider}
             </option>
           ))}
-        </select>
+        </Select>
       </div>
-      <ul className="grid w-full gap-6 md:grid-cols-4 grid-cols-2">
+
+      <ul className="grid w-full gap-4 grid-cols-2 md:grid-cols-4 lg:grid-cols-5">
         {providers.map((provider) => (
           <RadioCard
             key={provider.id}

--- a/components/RadioCard/index.jsx
+++ b/components/RadioCard/index.jsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { motion } from "framer-motion";
 import { cn } from "../../src/lib/utils";
+import { Check } from "lucide-react";
 
 const RadioCard = ({ item, value, handleInputChange, formData }) => {
   const isSelected = formData === item.value;
@@ -15,24 +17,40 @@ const RadioCard = ({ item, value, handleInputChange, formData }) => {
         onChange={handleInputChange}
         checked={isSelected}
       />
-      <label
+      <motion.label
         htmlFor={item.id}
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
         className={cn(
-          "flex w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 p-4 transition-all hover:bg-accent",
+          "relative flex w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 p-4 transition-colors duration-200",
           isSelected
-            ? "border-primary bg-accent shadow-sm"
-            : "border-border hover:border-muted-foreground/25"
+            ? "border-primary bg-accent shadow-sm glow-sm"
+            : "border-border/50 hover:border-border hover:bg-accent/50"
         )}
       >
-        <span className="text-sm font-semibold">{item.name}</span>
+        {isSelected && (
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary shadow-sm"
+          >
+            <Check className="h-3 w-3 text-primary-foreground" strokeWidth={3} />
+          </motion.div>
+        )}
         {item.src && (
           <img
             src={item.src}
-            className="h-16 w-auto object-contain"
+            className="h-12 w-auto object-contain opacity-80 transition-opacity group-hover:opacity-100"
             alt={item.name}
           />
         )}
-      </label>
+        <span className={cn(
+          "text-xs font-semibold text-center leading-tight",
+          isSelected ? "text-accent-foreground" : "text-muted-foreground"
+        )}>
+          {item.name}
+        </span>
+      </motion.label>
     </li>
   );
 };

--- a/components/RadioCard/index.jsx
+++ b/components/RadioCard/index.jsx
@@ -1,32 +1,39 @@
 import React from "react";
+import { cn } from "../../src/lib/utils";
+
 const RadioCard = ({ item, value, handleInputChange, formData }) => {
+  const isSelected = formData === item.value;
+
   return (
-    <>
-      <li key={item.id}>
-        <input
-          type="radio"
-          id={item.id}
-          name={value}
-          value={item.value}
-          className=" hidden"
-          onChange={handleInputChange}
-          checked={formData === item.value}
-        />
-        <label
-          htmlFor={item.id}
-          className={`inline-flex w-full cursor-pointer items-center justify-between rounded-lg border bg-white p-5 hover:bg-gray-100 hover:text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:hover:text-gray-300 transition-colors ${formData === item.value ? "border-blue-600 text-blue-600 dark:border-blue-500 dark:text-blue-500" : "border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400"}`}
-        >
-          <div className="flex-col items-center justify-center w-full">
-            <div className="text-center text-lg font-semibold">{item.name}</div>
-            {item.src ? (
-              <div className="flex justify-center items-center">
-                <img src={item.src} className="h-20" />
-              </div>
-            ) : null}
-          </div>
-        </label>
-      </li>
-    </>
+    <li>
+      <input
+        type="radio"
+        id={item.id}
+        name={value}
+        value={item.value}
+        className="hidden"
+        onChange={handleInputChange}
+        checked={isSelected}
+      />
+      <label
+        htmlFor={item.id}
+        className={cn(
+          "flex w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 p-4 transition-all hover:bg-accent",
+          isSelected
+            ? "border-primary bg-accent shadow-sm"
+            : "border-border hover:border-muted-foreground/25"
+        )}
+      >
+        <span className="text-sm font-semibold">{item.name}</span>
+        {item.src && (
+          <img
+            src={item.src}
+            className="h-16 w-auto object-contain"
+            alt={item.name}
+          />
+        )}
+      </label>
+    </li>
   );
 };
 

--- a/components/TextInput/index.jsx
+++ b/components/TextInput/index.jsx
@@ -1,16 +1,12 @@
 import React from "react";
+import { Input } from "../../src/components/ui/input";
+import { Label } from "../../src/components/ui/label";
+
 const TextInput = ({ name, value, holder, type, handleInputChange, formData, children }) => {
   return (
-    <div className="mb-4">
-      <label
-        className="block text-gray-700 dark:text-gray-200 font-bold mb-2"
-        htmlFor={name}
-        required
-      >
-        {name}
-      </label>
-      <input
-        className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+    <div className="space-y-2 mb-6">
+      <Label htmlFor={value}>{name}</Label>
+      <Input
         type={type || "text"}
         name={value}
         id={value}

--- a/components/TextInput/index.jsx
+++ b/components/TextInput/index.jsx
@@ -4,8 +4,10 @@ import { Label } from "../../src/components/ui/label";
 
 const TextInput = ({ name, value, holder, type, handleInputChange, formData, children }) => {
   return (
-    <div className="space-y-2 mb-6">
-      <Label htmlFor={value}>{name}</Label>
+    <div className="space-y-2">
+      <Label htmlFor={value} className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {name}
+      </Label>
       <Input
         type={type || "text"}
         name={value}

--- a/components/ThemeToggle/index.jsx
+++ b/components/ThemeToggle/index.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from "react";
+import { Button } from "../../src/components/ui/button";
+import { Moon, Sun } from "lucide-react";
 
 const ThemeToggle = () => {
   const [dark, setDark] = useState(() => {
@@ -22,26 +24,14 @@ const ThemeToggle = () => {
   }, [dark]);
 
   return (
-    <button
-      type="button"
+    <Button
+      variant="ghost"
+      size="icon"
       onClick={() => setDark((prev) => !prev)}
-      className="p-2 rounded-lg text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:focus:ring-gray-600 transition-colors"
       aria-label="Toggle dark mode"
     >
-      {dark ? (
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-          <path
-            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-            fillRule="evenodd"
-            clipRule="evenodd"
-          />
-        </svg>
-      ) : (
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-        </svg>
-      )}
-    </button>
+      {dark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
   );
 };
 

--- a/index.html
+++ b/index.html
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <link rel="icon" type="image/svg+xml" href="images/vagrant-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>
       Vagrantfile Generator - Online Tool to Generate Vagrant Configuration
       Files
@@ -27,7 +30,16 @@
       href="https://github.com/jianan1104/vagrant-config-generator"
     />
   </head>
-  <body>
+  <body class="min-h-screen bg-background font-sans antialiased">
+    <script>
+      // Apply saved theme or default to dark before React loads
+      (function() {
+        var theme = localStorage.getItem('theme');
+        if (theme === 'light') {
+          document.documentElement.classList.remove('dark');
+        }
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <title>
       Vagrantfile Generator - Online Tool to Generate Vagrant Configuration
       Files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2154 @@
+{
+  "name": "vagrant-config-generator",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vagrant-config-generator",
+      "version": "0.0.0",
+      "dependencies": {
+        "ace-builds": "^1.15.3",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "file-saver": "^2.0.5",
+        "handlebars": "^4.7.7",
+        "lucide-react": "^0.563.0",
+        "react": "^18.2.0",
+        "react-ace": "^10.1.0",
+        "react-dom": "^18.2.0",
+        "react-github-btn": "^1.4.0",
+        "tailwind-merge": "^3.4.0",
+        "tailwindcss-animate": "^1.0.7"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.27",
+        "@types/react-dom": "^18.0.10",
+        "@vitejs/plugin-react-swc": "^3.0.0",
+        "autoprefixer": "^10.4.14",
+        "postcss": "^8.4.21",
+        "tailwindcss": "^3.2.7",
+        "vite": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/core": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
+      "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.11",
+        "@swc/core-darwin-x64": "1.15.11",
+        "@swc/core-linux-arm-gnueabihf": "1.15.11",
+        "@swc/core-linux-arm64-gnu": "1.15.11",
+        "@swc/core-linux-arm64-musl": "1.15.11",
+        "@swc/core-linux-x64-gnu": "1.15.11",
+        "@swc/core-linux-x64-musl": "1.15.11",
+        "@swc/core-win32-arm64-msvc": "1.15.11",
+        "@swc/core-win32-ia32-msvc": "1.15.11",
+        "@swc/core-win32-x64-msvc": "1.15.11"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.11.tgz",
+      "integrity": "sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.11.tgz",
+      "integrity": "sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.11.tgz",
+      "integrity": "sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.11.tgz",
+      "integrity": "sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.11.tgz",
+      "integrity": "sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.11.tgz",
+      "integrity": "sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.11.tgz",
+      "integrity": "sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.11.tgz",
+      "integrity": "sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.11.tgz",
+      "integrity": "sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.11.tgz",
+      "integrity": "sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react-swc": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.11.0.tgz",
+      "integrity": "sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@swc/core": "^1.12.11"
+      },
+      "peerDependencies": {
+        "vite": "^4 || ^5 || ^6 || ^7"
+      }
+    },
+    "node_modules/ace-builds": {
+      "version": "1.43.6",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.6.tgz",
+      "integrity": "sha512-L1ddibQ7F3vyXR2k2fg+I8TQTPWVA6CKeDQr/h2+8CeyTp3W6EQL8xNFZRTztuP8xNOAqL3IYPqdzs31GCjDvg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.24",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
+      "integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001766",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001769",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/github-buttons": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/github-buttons/-/github-buttons-2.31.0.tgz",
+      "integrity": "sha512-XaR6cZEvVkLMnHv8K3j6FmZLAEH8AMuEkiBPj/vSHU8nt0iW5vYxhIa70ZPc4DsKAg7Latg3CcfIju/KunFaTQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.563.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
+      "integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-ace": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-10.1.0.tgz",
+      "integrity": "sha512-VkvUjZNhdYTuKOKQpMIZi7uzZZVgzCjM7cLYu6F64V0mejY8a2XTyPUIMszC6A4trbeMIHbK5fYFcT/wkP/8VA==",
+      "license": "MIT",
+      "dependencies": {
+        "ace-builds": "^1.4.14",
+        "diff-match-patch": "^1.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-github-btn": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-github-btn/-/react-github-btn-1.4.0.tgz",
+      "integrity": "sha512-lV4FYClAfjWnBfv0iNlJUGhamDgIq6TayD0kPZED6VzHWdpcHmPfsYOZ/CFwLfPv4Zp+F4m8QKTj0oy2HjiGXg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "github-buttons": "^2.22.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
+      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "file-saver": "^2.0.5",
+        "framer-motion": "^12.33.0",
         "handlebars": "^4.7.7",
         "lucide-react": "^0.563.0",
         "react": "^18.2.0",
@@ -1158,6 +1159,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.33.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.33.0.tgz",
+      "integrity": "sha512-ca8d+rRPcDP5iIF+MoT3WNc0KHJMjIyFAbtVLvM9eA7joGSpeqDfiNH/kCs1t4CHi04njYvWyj0jS4QlEK/rJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.33.0",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1387,6 +1415,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.33.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.33.0.tgz",
+      "integrity": "sha512-XRPebVypsl0UM+7v0Hr8o9UAj0S2djsQWRdHBd5iVouVpMrQqAI0C/rDAT3QaYnXnHuC5hMcwDHCboNeyYjPoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -2037,6 +2080,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,17 @@
   },
   "dependencies": {
     "ace-builds": "^1.15.3",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "file-saver": "^2.0.5",
-    "flowbite": "^1.6.4",
-    "flowbite-react": "^0.4.2",
     "handlebars": "^4.7.7",
+    "lucide-react": "^0.563.0",
     "react": "^18.2.0",
     "react-ace": "^10.1.0",
     "react-dom": "^18.2.0",
-    "react-github-btn": "^1.4.0"
+    "react-github-btn": "^1.4.0",
+    "tailwind-merge": "^3.4.0",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@types/react": "^18.0.27",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "file-saver": "^2.0.5",
+    "framer-motion": "^12.33.0",
     "handlebars": "^4.7.7",
     "lucide-react": "^0.563.0",
     "react": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Navbar, Footer, TextInput, RadioCard, ProviderSelect } from "../components";
 import { boxes, cpuOptions, memoryOptions } from "../components/constants";
 import { useVagrantConfig } from "./hooks/useVagrantConfig";
@@ -7,14 +8,212 @@ import { Button } from "./components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "./components/ui/card";
 import { Label } from "./components/ui/label";
 import { Checkbox } from "./components/ui/checkbox";
-import { Separator } from "./components/ui/separator";
-import { Download, Play, ExternalLink } from "lucide-react";
+import { Badge } from "./components/ui/badge";
+import {
+  Download,
+  Play,
+  ExternalLink,
+  Monitor,
+  Server,
+  Cpu,
+  Network,
+  Check,
+  Copy,
+  ChevronRight,
+  Terminal,
+  Sparkles,
+} from "lucide-react";
 
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-ruby";
 import "ace-builds/src-noconflict/theme-one_dark";
 
+const STEPS = [
+  { id: "os", label: "Base Image", icon: Monitor, description: "Choose your operating system" },
+  { id: "provider", label: "Provider", icon: Server, description: "Select virtualization provider" },
+  { id: "resources", label: "Resources", icon: Cpu, description: "Configure CPU, memory & disk" },
+  { id: "network", label: "Network", icon: Network, description: "Set identity & networking" },
+];
+
+const StepIndicator = ({ steps, activeStep, onStepClick, generated }) => (
+  <nav className="flex items-center gap-1 overflow-x-auto pb-2 scrollbar-hide">
+    {steps.map((step, index) => {
+      const isActive = activeStep === index;
+      const isPast = activeStep > index;
+      const Icon = step.icon;
+
+      return (
+        <React.Fragment key={step.id}>
+          <button
+            type="button"
+            onClick={() => onStepClick(index)}
+            className={`
+              flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-200 whitespace-nowrap
+              ${isActive
+                ? "bg-primary/10 text-primary"
+                : isPast
+                  ? "text-foreground hover:bg-accent"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
+              }
+            `}
+          >
+            <div className={`
+              flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold transition-all duration-200
+              ${isActive
+                ? "bg-primary text-primary-foreground shadow-sm"
+                : isPast
+                  ? "bg-primary/20 text-primary"
+                  : "bg-muted text-muted-foreground"
+              }
+            `}>
+              {isPast ? <Check className="h-3.5 w-3.5" /> : <Icon className="h-3.5 w-3.5" />}
+            </div>
+            <span className="hidden sm:inline">{step.label}</span>
+          </button>
+          {index < steps.length - 1 && (
+            <ChevronRight className="h-4 w-4 text-border flex-shrink-0" />
+          )}
+        </React.Fragment>
+      );
+    })}
+  </nav>
+);
+
+const TerminalPreview = ({ config, downloadLink, generated, onEditorChange }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(config);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const textarea = document.createElement("textarea");
+      textarea.value = config;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [config]);
+
+  if (!generated) {
+    return (
+      <div className="rounded-xl border border-dashed border-border/60 bg-card">
+        <div className="flex flex-col items-center justify-center py-20 text-center px-6">
+          <div className="rounded-2xl bg-accent/50 p-5 mb-5">
+            <Terminal className="h-10 w-10 text-muted-foreground/60" />
+          </div>
+          <h3 className="text-base font-semibold mb-2">Your Vagrantfile will appear here</h3>
+          <p className="text-sm text-muted-foreground max-w-[280px] leading-relaxed">
+            Configure your VM settings and hit Generate to see a live, editable preview.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="rounded-xl border border-border overflow-hidden shadow-lg"
+    >
+      {/* Terminal Title Bar */}
+      <div className="terminal-bg flex items-center justify-between px-4 py-3 border-b border-white/[0.06]">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5">
+            <div className="h-3 w-3 rounded-full bg-[#ff5f57]" />
+            <div className="h-3 w-3 rounded-full bg-[#febc2e]" />
+            <div className="h-3 w-3 rounded-full bg-[#28c840]" />
+          </div>
+          <span className="text-xs text-white/40 font-mono">Vagrantfile</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCopy}
+            className="h-7 px-2.5 text-white/50 hover:text-white hover:bg-white/10 transition-colors"
+            type="button"
+          >
+            <AnimatePresence mode="wait">
+              {copied ? (
+                <motion.div
+                  key="check"
+                  initial={{ scale: 0.5, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.5, opacity: 0 }}
+                  className="flex items-center gap-1.5"
+                >
+                  <Check className="h-3.5 w-3.5 text-emerald-400" />
+                  <span className="text-xs text-emerald-400">Copied</span>
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="copy"
+                  initial={{ scale: 0.5, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.5, opacity: 0 }}
+                  className="flex items-center gap-1.5"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                  <span className="text-xs">Copy</span>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </Button>
+          <a href={downloadLink} download="Vagrantfile">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2.5 text-white/50 hover:text-white hover:bg-white/10 transition-colors"
+              type="button"
+            >
+              <Download className="h-3.5 w-3.5 mr-1.5" />
+              <span className="text-xs">Download</span>
+            </Button>
+          </a>
+        </div>
+      </div>
+
+      {/* Editor */}
+      <div className="terminal-bg">
+        <AceEditor
+          mode="ruby"
+          theme="one_dark"
+          name="editor"
+          onChange={onEditorChange}
+          fontSize={13}
+          showPrintMargin={false}
+          showGutter={true}
+          highlightActiveLine={true}
+          value={config}
+          width="100%"
+          height="520px"
+          style={{ background: "transparent", fontFamily: "'JetBrains Mono', 'Fira Code', monospace" }}
+          setOptions={{
+            showLineNumbers: true,
+            tabSize: 2,
+            fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+          }}
+        />
+      </div>
+    </motion.div>
+  );
+};
+
+const stepVariants = {
+  hidden: { opacity: 0, x: 20 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.25, ease: "easeOut" } },
+  exit: { opacity: 0, x: -20, transition: { duration: 0.15 } },
+};
+
 const VagrantConfigGenerator = () => {
+  const [activeStep, setActiveStep] = useState(0);
   const {
     formData,
     config,
@@ -27,248 +226,303 @@ const VagrantConfigGenerator = () => {
     onEditorChange,
   } = useVagrantConfig();
 
+  const isLastStep = activeStep === STEPS.length - 1;
+
+  const handleNext = () => {
+    if (isLastStep) return;
+    setActiveStep((prev) => prev + 1);
+  };
+
+  const handleBack = () => {
+    if (activeStep === 0) return;
+    setActiveStep((prev) => prev - 1);
+  };
+
+  const handleGenerate = (e) => {
+    handleFinish(e);
+  };
+
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
 
-      <main className="container py-8">
-        <div className="mb-8 space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight">
-            Configure Your Vagrantfile
+      <main className="container py-8 lg:py-12">
+        {/* Hero Header */}
+        <div className="mb-10 max-w-2xl">
+          <div className="flex items-center gap-2 mb-4">
+            <Badge variant="secondary" className="font-mono text-[10px] px-2 py-0.5">
+              Infrastructure as Code
+            </Badge>
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+            Build your{" "}
+            <span className="gradient-text">Vagrantfile</span>
           </h1>
-          <p className="text-muted-foreground">
-            Select your options below and generate a ready-to-use Vagrant configuration.
+          <p className="text-muted-foreground text-base leading-relaxed">
+            Configure your virtual machine step by step and generate a production-ready Vagrant configuration in seconds.
           </p>
         </div>
 
         <div className="grid gap-8 lg:grid-cols-[1fr,1fr] xl:grid-cols-[3fr,2fr]">
-          {/* Configuration Form */}
+          {/* Configuration Panel */}
           <div className="space-y-6">
-            <form onSubmit={handleFinish} className="space-y-6">
-              {/* Box Selection */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">Operating System</CardTitle>
-                  <CardDescription>
-                    Choose a base box or{" "}
-                    <a
-                      target="_blank"
-                      rel="noreferrer"
-                      href="https://app.vagrantup.com/boxes/search"
-                      className="font-medium text-primary underline underline-offset-4 hover:text-primary/80"
-                    >
-                      search for more
-                      <ExternalLink className="ml-1 inline h-3 w-3" />
-                    </a>
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <TextInput
-                    handleInputChange={handleInputChange}
-                    formData={formData.box}
-                    name="Box Image"
-                    value="box"
-                    holder="ubuntu/jammy64"
-                  />
-                  <ul className="grid w-full gap-3 grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
-                    {boxes.map((box) => (
-                      <RadioCard
-                        key={box.id}
-                        item={box}
-                        value="box"
-                        handleInputChange={handleInputChange}
-                        formData={formData.box}
-                      />
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
+            {/* Step Navigation */}
+            <StepIndicator
+              steps={STEPS}
+              activeStep={activeStep}
+              onStepClick={setActiveStep}
+              generated={generated}
+            />
 
-              {/* Provider Selection */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">Provider</CardTitle>
-                  <CardDescription>
-                    Select a virtualization provider for your VM.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ProviderSelect
-                    formData={formData}
-                    handleInputChange={handleInputChange}
-                    handleGroupChange={handleGroupChange}
-                    selectedGroup={selectedGroup}
-                  />
-                </CardContent>
-              </Card>
-
-              {/* Resources */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">Resources</CardTitle>
-                  <CardDescription>
-                    Configure CPU, memory, and disk allocation.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                  <div className="space-y-3">
-                    <Label>CPUs</Label>
-                    <ul className="grid w-full gap-3 grid-cols-4 md:grid-cols-8">
-                      {cpuOptions.map((cpuOption) => (
-                        <RadioCard
-                          key={cpuOption.id}
-                          item={cpuOption}
-                          value="cpus"
+            <form onSubmit={handleGenerate}>
+              <AnimatePresence mode="wait">
+                {/* Step 0: OS Selection */}
+                {activeStep === 0 && (
+                  <motion.div key="step-os" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
+                    <Card>
+                      <CardHeader>
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                            <Monitor className="h-4.5 w-4.5 text-primary" />
+                          </div>
+                          <div>
+                            <CardTitle className="text-lg">Operating System</CardTitle>
+                            <CardDescription>
+                              Choose a base box or{" "}
+                              <a
+                                target="_blank"
+                                rel="noreferrer"
+                                href="https://app.vagrantup.com/boxes/search"
+                                className="font-medium text-primary hover:text-primary/80 transition-colors"
+                              >
+                                search Vagrant Cloud
+                                <ExternalLink className="ml-1 inline h-3 w-3" />
+                              </a>
+                            </CardDescription>
+                          </div>
+                        </div>
+                      </CardHeader>
+                      <CardContent className="space-y-5">
+                        <TextInput
                           handleInputChange={handleInputChange}
-                          formData={formData.cpus}
+                          formData={formData.box}
+                          name="Box Image"
+                          value="box"
+                          holder="e.g. ubuntu/jammy64"
                         />
-                      ))}
-                    </ul>
-                  </div>
+                        <ul className="grid w-full gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+                          {boxes.map((box) => (
+                            <RadioCard
+                              key={box.id}
+                              item={box}
+                              value="box"
+                              handleInputChange={handleInputChange}
+                              formData={formData.box}
+                            />
+                          ))}
+                        </ul>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                )}
 
-                  <Separator />
-
-                  <div className="space-y-3">
-                    <Label>Memory</Label>
-                    <ul className="grid w-full gap-3 grid-cols-2 md:grid-cols-4">
-                      {memoryOptions.map((memoryOption) => (
-                        <RadioCard
-                          key={memoryOption.id}
-                          item={memoryOption}
-                          value="memory"
+                {/* Step 1: Provider */}
+                {activeStep === 1 && (
+                  <motion.div key="step-provider" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
+                    <Card>
+                      <CardHeader>
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                            <Server className="h-4.5 w-4.5 text-primary" />
+                          </div>
+                          <div>
+                            <CardTitle className="text-lg">Virtualization Provider</CardTitle>
+                            <CardDescription>
+                              Select the backend that powers your virtual machines.
+                            </CardDescription>
+                          </div>
+                        </div>
+                      </CardHeader>
+                      <CardContent>
+                        <ProviderSelect
+                          formData={formData}
                           handleInputChange={handleInputChange}
-                          formData={formData.memory}
+                          handleGroupChange={handleGroupChange}
+                          selectedGroup={selectedGroup}
                         />
-                      ))}
-                    </ul>
-                  </div>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                )}
 
-                  <Separator />
+                {/* Step 2: Resources */}
+                {activeStep === 2 && (
+                  <motion.div key="step-resources" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
+                    <Card>
+                      <CardHeader>
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                            <Cpu className="h-4.5 w-4.5 text-primary" />
+                          </div>
+                          <div>
+                            <CardTitle className="text-lg">Resources</CardTitle>
+                            <CardDescription>
+                              Allocate compute, memory, and storage for your VM.
+                            </CardDescription>
+                          </div>
+                        </div>
+                      </CardHeader>
+                      <CardContent className="space-y-6">
+                        <div className="space-y-3">
+                          <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">CPUs</Label>
+                          <ul className="grid w-full gap-2.5 grid-cols-4 md:grid-cols-8">
+                            {cpuOptions.map((cpuOption) => (
+                              <RadioCard
+                                key={cpuOption.id}
+                                item={cpuOption}
+                                value="cpus"
+                                handleInputChange={handleInputChange}
+                                formData={formData.cpus}
+                              />
+                            ))}
+                          </ul>
+                        </div>
 
-                  <TextInput
-                    handleInputChange={handleInputChange}
-                    formData={formData.disk_size}
-                    name="Disk Size"
-                    value="disk_size"
-                    holder="20GB"
-                  />
-                </CardContent>
-              </Card>
+                        <div className="h-px bg-border/50" />
 
-              {/* Network & Identity */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">Network & Identity</CardTitle>
-                  <CardDescription>
-                    Set machine name, hostname, IP, and instance count.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <TextInput
-                      handleInputChange={handleInputChange}
-                      formData={formData.name}
-                      name="Machine Name"
-                      value="name"
-                      holder="VM Name"
-                    />
-                    <TextInput
-                      handleInputChange={handleInputChange}
-                      formData={formData.hostname}
-                      name="Host Name"
-                      value="hostname"
-                      holder="webserver"
-                    />
-                  </div>
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <TextInput
-                      handleInputChange={handleInputChange}
-                      formData={formData.ip}
-                      name="IP Address"
-                      value="ip"
-                      holder="192.168.33.10"
-                    />
-                    <TextInput
-                      handleInputChange={handleInputChange}
-                      formData={formData.count}
-                      name="Count"
-                      value="count"
-                      holder="1"
-                      type="number"
-                    />
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="iterationStartFrom0"
-                      name="iterationStartFrom0"
-                      checked={formData.iterationStartFrom0}
-                      onChange={handleInputChange}
-                    />
-                    <Label htmlFor="iterationStartFrom0" className="cursor-pointer">
-                      Start iteration from 0
-                    </Label>
-                  </div>
-                </CardContent>
-              </Card>
+                        <div className="space-y-3">
+                          <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Memory</Label>
+                          <ul className="grid w-full gap-2.5 grid-cols-2 md:grid-cols-4">
+                            {memoryOptions.map((memoryOption) => (
+                              <RadioCard
+                                key={memoryOption.id}
+                                item={memoryOption}
+                                value="memory"
+                                handleInputChange={handleInputChange}
+                                formData={formData.memory}
+                              />
+                            ))}
+                          </ul>
+                        </div>
 
-              {/* Generate Button */}
-              <Button type="submit" size="lg" className="w-full sm:w-auto">
-                <Play className="mr-2 h-4 w-4" />
-                Generate Vagrantfile
-              </Button>
+                        <div className="h-px bg-border/50" />
+
+                        <TextInput
+                          handleInputChange={handleInputChange}
+                          formData={formData.disk_size}
+                          name="Disk Size"
+                          value="disk_size"
+                          holder="e.g. 20GB"
+                        />
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                )}
+
+                {/* Step 3: Network & Identity */}
+                {activeStep === 3 && (
+                  <motion.div key="step-network" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
+                    <Card>
+                      <CardHeader>
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                            <Network className="h-4.5 w-4.5 text-primary" />
+                          </div>
+                          <div>
+                            <CardTitle className="text-lg">Network & Identity</CardTitle>
+                            <CardDescription>
+                              Configure machine identity, networking, and scaling.
+                            </CardDescription>
+                          </div>
+                        </div>
+                      </CardHeader>
+                      <CardContent className="space-y-5">
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          <TextInput
+                            handleInputChange={handleInputChange}
+                            formData={formData.name}
+                            name="Machine Name"
+                            value="name"
+                            holder="e.g. webserver"
+                          />
+                          <TextInput
+                            handleInputChange={handleInputChange}
+                            formData={formData.hostname}
+                            name="Host Name"
+                            value="hostname"
+                            holder="e.g. webserver.local"
+                          />
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          <TextInput
+                            handleInputChange={handleInputChange}
+                            formData={formData.ip}
+                            name="IP Address"
+                            value="ip"
+                            holder="e.g. 192.168.33.10"
+                          />
+                          <TextInput
+                            handleInputChange={handleInputChange}
+                            formData={formData.count}
+                            name="Instance Count"
+                            value="count"
+                            holder="1"
+                            type="number"
+                          />
+                        </div>
+                        <div className="flex items-center space-x-2.5 pt-1">
+                          <Checkbox
+                            id="iterationStartFrom0"
+                            name="iterationStartFrom0"
+                            checked={formData.iterationStartFrom0}
+                            onChange={handleInputChange}
+                          />
+                          <Label htmlFor="iterationStartFrom0" className="cursor-pointer text-sm">
+                            Start iteration from 0
+                          </Label>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
+              {/* Navigation Buttons */}
+              <div className="flex items-center justify-between mt-6">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={handleBack}
+                  disabled={activeStep === 0}
+                  className="text-muted-foreground"
+                >
+                  Back
+                </Button>
+                <div className="flex items-center gap-3">
+                  {!isLastStep ? (
+                    <Button type="button" onClick={handleNext}>
+                      Continue
+                      <ChevronRight className="ml-1.5 h-4 w-4" />
+                    </Button>
+                  ) : (
+                    <Button type="submit" variant="glow" size="lg">
+                      <Sparkles className="mr-2 h-4 w-4" />
+                      Generate Vagrantfile
+                    </Button>
+                  )}
+                </div>
+              </div>
             </form>
           </div>
 
           {/* Preview Panel */}
-          <div className="lg:sticky lg:top-20 lg:self-start space-y-4">
-            {generated ? (
-              <Card>
-                <CardHeader className="pb-3">
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-lg">Preview</CardTitle>
-                    <a href={downloadLink} download="Vagrantfile">
-                      <Button variant="outline" size="sm" type="button">
-                        <Download className="mr-2 h-4 w-4" />
-                        Download
-                      </Button>
-                    </a>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="overflow-hidden rounded-md border">
-                    <AceEditor
-                      mode="ruby"
-                      theme="one_dark"
-                      name="editor"
-                      onChange={onEditorChange}
-                      fontSize={13}
-                      showPrintMargin={false}
-                      showGutter={true}
-                      highlightActiveLine={true}
-                      value={config}
-                      width="100%"
-                      height="500px"
-                      setOptions={{
-                        showLineNumbers: true,
-                        tabSize: 2,
-                      }}
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-            ) : (
-              <Card className="border-dashed">
-                <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-                  <div className="rounded-full bg-muted p-4 mb-4">
-                    <Play className="h-8 w-8 text-muted-foreground" />
-                  </div>
-                  <h3 className="text-lg font-semibold mb-1">No preview yet</h3>
-                  <p className="text-sm text-muted-foreground max-w-[250px]">
-                    Configure your VM settings and click "Generate Vagrantfile" to see a preview.
-                  </p>
-                </CardContent>
-              </Card>
-            )}
+          <div className="lg:sticky lg:top-24 lg:self-start">
+            <TerminalPreview
+              config={config}
+              downloadLink={downloadLink}
+              generated={generated}
+              onEditorChange={onEditorChange}
+            />
           </div>
         </div>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,9 +3,16 @@ import { Navbar, Footer, TextInput, RadioCard, ProviderSelect } from "../compone
 import { boxes, cpuOptions, memoryOptions } from "../components/constants";
 import { useVagrantConfig } from "./hooks/useVagrantConfig";
 
+import { Button } from "./components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "./components/ui/card";
+import { Label } from "./components/ui/label";
+import { Checkbox } from "./components/ui/checkbox";
+import { Separator } from "./components/ui/separator";
+import { Download, Play, ExternalLink } from "lucide-react";
+
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-ruby";
-import "ace-builds/src-noconflict/theme-monokai";
+import "ace-builds/src-noconflict/theme-one_dark";
 
 const VagrantConfigGenerator = () => {
   const {
@@ -21,182 +28,253 @@ const VagrantConfigGenerator = () => {
   } = useVagrantConfig();
 
   return (
-    <>
+    <div className="min-h-screen bg-background">
       <Navbar />
-      <div className="container mx-auto my-4 p-4 transition-colors duration-200">
-        <form onSubmit={handleFinish}>
-          <TextInput
-            handleInputChange={handleInputChange}
-            formData={formData.box}
-            name="Box"
-            value="box"
-          >
-            <p
-              id="helper-text-explanation"
-              className="mt-2 text-sm text-gray-500 dark:text-gray-400 mb-2"
-            >
-              Want to search a box? Find{" "}
-              <a
-                target="_blank"
-                rel="noreferrer"
-                href="https://app.vagrantup.com/boxes/search"
-                className="font-medium text-blue-600 hover:underline dark:text-blue-500"
-              >
-                boxes
-              </a>
-              .
-            </p>
-            <ul className="grid w-full gap-6 md:grid-cols-4 grid-cols-2">
-              {boxes.map((box) => (
-                <RadioCard
-                  key={box.id}
-                  item={box}
-                  value="box"
-                  handleInputChange={handleInputChange}
-                  formData={formData.box}
-                />
-              ))}
-            </ul>
-          </TextInput>
-          
-          <ProviderSelect 
-            formData={formData}
-            handleInputChange={handleInputChange}
-            handleGroupChange={handleGroupChange}
-            selectedGroup={selectedGroup}
-          />
 
-          <div className="mb-4">
-            <label
-              className="block text-gray-700 dark:text-gray-200 font-bold mb-2"
-              htmlFor="cpus"
-            >
-              CPUs
-            </label>
-            <ul className="grid w-full gap-6 md:grid-cols-4 grid-cols-2">
-              {cpuOptions.map((cpuOption) => (
-                <RadioCard
-                  key={cpuOption.id}
-                  item={cpuOption}
-                  value="cpus"
-                  handleInputChange={handleInputChange}
-                  formData={formData.cpus}
-                />
-              ))}
-            </ul>
+      <main className="container py-8">
+        <div className="mb-8 space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Configure Your Vagrantfile
+          </h1>
+          <p className="text-muted-foreground">
+            Select your options below and generate a ready-to-use Vagrant configuration.
+          </p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-[1fr,1fr] xl:grid-cols-[3fr,2fr]">
+          {/* Configuration Form */}
+          <div className="space-y-6">
+            <form onSubmit={handleFinish} className="space-y-6">
+              {/* Box Selection */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-lg">Operating System</CardTitle>
+                  <CardDescription>
+                    Choose a base box or{" "}
+                    <a
+                      target="_blank"
+                      rel="noreferrer"
+                      href="https://app.vagrantup.com/boxes/search"
+                      className="font-medium text-primary underline underline-offset-4 hover:text-primary/80"
+                    >
+                      search for more
+                      <ExternalLink className="ml-1 inline h-3 w-3" />
+                    </a>
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <TextInput
+                    handleInputChange={handleInputChange}
+                    formData={formData.box}
+                    name="Box Image"
+                    value="box"
+                    holder="ubuntu/jammy64"
+                  />
+                  <ul className="grid w-full gap-3 grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+                    {boxes.map((box) => (
+                      <RadioCard
+                        key={box.id}
+                        item={box}
+                        value="box"
+                        handleInputChange={handleInputChange}
+                        formData={formData.box}
+                      />
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+
+              {/* Provider Selection */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-lg">Provider</CardTitle>
+                  <CardDescription>
+                    Select a virtualization provider for your VM.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ProviderSelect
+                    formData={formData}
+                    handleInputChange={handleInputChange}
+                    handleGroupChange={handleGroupChange}
+                    selectedGroup={selectedGroup}
+                  />
+                </CardContent>
+              </Card>
+
+              {/* Resources */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-lg">Resources</CardTitle>
+                  <CardDescription>
+                    Configure CPU, memory, and disk allocation.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="space-y-3">
+                    <Label>CPUs</Label>
+                    <ul className="grid w-full gap-3 grid-cols-4 md:grid-cols-8">
+                      {cpuOptions.map((cpuOption) => (
+                        <RadioCard
+                          key={cpuOption.id}
+                          item={cpuOption}
+                          value="cpus"
+                          handleInputChange={handleInputChange}
+                          formData={formData.cpus}
+                        />
+                      ))}
+                    </ul>
+                  </div>
+
+                  <Separator />
+
+                  <div className="space-y-3">
+                    <Label>Memory</Label>
+                    <ul className="grid w-full gap-3 grid-cols-2 md:grid-cols-4">
+                      {memoryOptions.map((memoryOption) => (
+                        <RadioCard
+                          key={memoryOption.id}
+                          item={memoryOption}
+                          value="memory"
+                          handleInputChange={handleInputChange}
+                          formData={formData.memory}
+                        />
+                      ))}
+                    </ul>
+                  </div>
+
+                  <Separator />
+
+                  <TextInput
+                    handleInputChange={handleInputChange}
+                    formData={formData.disk_size}
+                    name="Disk Size"
+                    value="disk_size"
+                    holder="20GB"
+                  />
+                </CardContent>
+              </Card>
+
+              {/* Network & Identity */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-lg">Network & Identity</CardTitle>
+                  <CardDescription>
+                    Set machine name, hostname, IP, and instance count.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <TextInput
+                      handleInputChange={handleInputChange}
+                      formData={formData.name}
+                      name="Machine Name"
+                      value="name"
+                      holder="VM Name"
+                    />
+                    <TextInput
+                      handleInputChange={handleInputChange}
+                      formData={formData.hostname}
+                      name="Host Name"
+                      value="hostname"
+                      holder="webserver"
+                    />
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <TextInput
+                      handleInputChange={handleInputChange}
+                      formData={formData.ip}
+                      name="IP Address"
+                      value="ip"
+                      holder="192.168.33.10"
+                    />
+                    <TextInput
+                      handleInputChange={handleInputChange}
+                      formData={formData.count}
+                      name="Count"
+                      value="count"
+                      holder="1"
+                      type="number"
+                    />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="iterationStartFrom0"
+                      name="iterationStartFrom0"
+                      checked={formData.iterationStartFrom0}
+                      onChange={handleInputChange}
+                    />
+                    <Label htmlFor="iterationStartFrom0" className="cursor-pointer">
+                      Start iteration from 0
+                    </Label>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Generate Button */}
+              <Button type="submit" size="lg" className="w-full sm:w-auto">
+                <Play className="mr-2 h-4 w-4" />
+                Generate Vagrantfile
+              </Button>
+            </form>
           </div>
-          <div className="mb-4">
-            <label
-              className="block text-gray-700 dark:text-gray-200 font-bold mb-2"
-              htmlFor="memory"
-            >
-              Memory
-            </label>
-            <ul className="grid w-full gap-6 md:grid-cols-4 grid-cols-2">
-              {memoryOptions.map((memoryOption) => (
-                <RadioCard
-                  key={memoryOption.id}
-                  item={memoryOption}
-                  value="memory"
-                  handleInputChange={handleInputChange}
-                  formData={formData.memory}
-                />
-              ))}
-            </ul>
+
+          {/* Preview Panel */}
+          <div className="lg:sticky lg:top-20 lg:self-start space-y-4">
+            {generated ? (
+              <Card>
+                <CardHeader className="pb-3">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-lg">Preview</CardTitle>
+                    <a href={downloadLink} download="Vagrantfile">
+                      <Button variant="outline" size="sm" type="button">
+                        <Download className="mr-2 h-4 w-4" />
+                        Download
+                      </Button>
+                    </a>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="overflow-hidden rounded-md border">
+                    <AceEditor
+                      mode="ruby"
+                      theme="one_dark"
+                      name="editor"
+                      onChange={onEditorChange}
+                      fontSize={13}
+                      showPrintMargin={false}
+                      showGutter={true}
+                      highlightActiveLine={true}
+                      value={config}
+                      width="100%"
+                      height="500px"
+                      setOptions={{
+                        showLineNumbers: true,
+                        tabSize: 2,
+                      }}
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <Card className="border-dashed">
+                <CardContent className="flex flex-col items-center justify-center py-16 text-center">
+                  <div className="rounded-full bg-muted p-4 mb-4">
+                    <Play className="h-8 w-8 text-muted-foreground" />
+                  </div>
+                  <h3 className="text-lg font-semibold mb-1">No preview yet</h3>
+                  <p className="text-sm text-muted-foreground max-w-[250px]">
+                    Configure your VM settings and click "Generate Vagrantfile" to see a preview.
+                  </p>
+                </CardContent>
+              </Card>
+            )}
           </div>
-          <TextInput
-            handleInputChange={handleInputChange}
-            formData={formData.disk_size}
-            name="Disk Size"
-            value="disk_size"
-            holder="20GB"
-          />
-          <TextInput
-            handleInputChange={handleInputChange}
-            formData={formData.name}
-            name="Machine Name"
-            value="name"
-            holder="VM Name"
-          />
-          <TextInput
-            handleInputChange={handleInputChange}
-            formData={formData.hostname}
-            name="Host Name"
-            value="hostname"
-            holder="webserver"
-          />
-          <TextInput
-            handleInputChange={handleInputChange}
-            formData={formData.ip}
-            name="IP Address"
-            value="ip"
-            holder="192.168.33.10"
-          />
-          <TextInput
-            handleInputChange={handleInputChange}
-            formData={formData.count}
-            name="Count"
-            value="count"
-            holder="1"
-            type="number"
-          />
-          <div className="mb-4 flex items-center">
-            <input
-              id="iterationStartFrom0"
-              type="checkbox"
-              name="iterationStartFrom0"
-              checked={formData.iterationStartFrom0}
-              onChange={handleInputChange}
-              className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-            />
-            <label
-              htmlFor="iterationStartFrom0"
-              className="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Start iteration from 0
-            </label>
-          </div>
-          <button
-            type="submit"
-            className="mb-4 bg-blue-500 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-800 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline transition-colors"
-          >
-            Generate Config
-          </button>
-        </form>
-        {generated && (
-          <div className="mb-4">
-            <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-              Preview 👀
-            </h2>
-            <AceEditor
-              className="mb-4"
-              mode="ruby"
-              theme="monokai"
-              name="editor"
-              onChange={onEditorChange}
-              fontSize={14}
-              showPrintMargin={true}
-              showGutter={true}
-              highlightActiveLine={true}
-              value={config}
-              width="100%"
-              setOptions={{
-                showLineNumbers: true,
-                tabSize: 2,
-              }}
-            />
-            <a
-              href={downloadLink}
-              download="Vagrantfile"
-              className="bg-green-500 hover:bg-green-700 dark:bg-green-600 dark:hover:bg-green-800 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline transition-colors"
-            >
-              Download Config
-            </a>
-          </div>
-        )}
+        </div>
+
         <Footer />
-      </div>
-    </>
+      </main>
+    </div>
   );
 };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,18 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Navbar, Footer, TextInput, RadioCard, ProviderSelect } from "../components";
 import { boxes, cpuOptions, memoryOptions } from "../components/constants";
 import { useVagrantConfig } from "./hooks/useVagrantConfig";
+import { useVagrantCloudSearch } from "./hooks/useVagrantCloudSearch";
 
 import { Button } from "./components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "./components/ui/card";
+import { Input } from "./components/ui/input";
 import { Label } from "./components/ui/label";
 import { Checkbox } from "./components/ui/checkbox";
 import { Badge } from "./components/ui/badge";
 import {
   Download,
-  Play,
   ExternalLink,
   Monitor,
   Server,
@@ -22,6 +23,9 @@ import {
   ChevronRight,
   Terminal,
   Sparkles,
+  Search,
+  Loader2,
+  Cloud,
 } from "lucide-react";
 
 import AceEditor from "react-ace";
@@ -35,48 +39,112 @@ const STEPS = [
   { id: "network", label: "Network", icon: Network, description: "Set identity & networking" },
 ];
 
-const StepIndicator = ({ steps, activeStep, onStepClick, generated }) => (
-  <nav className="flex items-center gap-1 overflow-x-auto pb-2 scrollbar-hide">
-    {steps.map((step, index) => {
-      const isActive = activeStep === index;
-      const isPast = activeStep > index;
-      const Icon = step.icon;
+const STEP_CONTAINER_HEIGHT = "550px";
 
-      return (
-        <React.Fragment key={step.id}>
-          <button
-            type="button"
-            onClick={() => onStepClick(index)}
-            className={`
-              flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-200 whitespace-nowrap
-              ${isActive
-                ? "bg-primary/10 text-primary"
-                : isPast
-                  ? "text-foreground hover:bg-accent"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
-              }
-            `}
-          >
-            <div className={`
-              flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold transition-all duration-200
-              ${isActive
-                ? "bg-primary text-primary-foreground shadow-sm"
-                : isPast
-                  ? "bg-primary/20 text-primary"
-                  : "bg-muted text-muted-foreground"
-              }
-            `}>
-              {isPast ? <Check className="h-3.5 w-3.5" /> : <Icon className="h-3.5 w-3.5" />}
-            </div>
-            <span className="hidden sm:inline">{step.label}</span>
-          </button>
-          {index < steps.length - 1 && (
-            <ChevronRight className="h-4 w-4 text-border flex-shrink-0" />
-          )}
-        </React.Fragment>
-      );
-    })}
-  </nav>
+const StepIndicator = ({ steps, activeStep, onStepClick }) => {
+  const progress = ((activeStep + 1) / steps.length) * 100;
+
+  return (
+    <div className="space-y-3">
+      {/* Progress Bar */}
+      <div className="flex items-center gap-3">
+        <div className="relative h-1.5 flex-1 rounded-full bg-muted overflow-hidden">
+          <motion.div
+            className="absolute inset-y-0 left-0 rounded-full bg-primary"
+            initial={{ width: 0 }}
+            animate={{ width: `${progress}%` }}
+            transition={{ duration: 0.35, ease: "easeOut" }}
+          />
+        </div>
+        <span className="text-xs font-medium text-muted-foreground tabular-nums">
+          {activeStep + 1}/{steps.length}
+        </span>
+      </div>
+
+      {/* Step Navigation */}
+      <nav className="flex items-center gap-1 overflow-x-auto pb-2 scrollbar-hide">
+        {steps.map((step, index) => {
+          const isActive = activeStep === index;
+          const isPast = activeStep > index;
+          const Icon = step.icon;
+
+          return (
+            <React.Fragment key={step.id}>
+              <button
+                type="button"
+                onClick={() => onStepClick(index)}
+                className={`
+                  flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-200 whitespace-nowrap
+                  ${isActive
+                    ? "bg-primary/10 text-primary"
+                    : isPast
+                      ? "text-foreground hover:bg-accent"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  }
+                `}
+              >
+                <div className={`
+                  flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold transition-all duration-200
+                  ${isActive
+                    ? "bg-primary text-primary-foreground shadow-sm"
+                    : isPast
+                      ? "bg-primary/20 text-primary"
+                      : "bg-muted text-muted-foreground"
+                  }
+                `}>
+                  {isPast ? <Check className="h-3.5 w-3.5" /> : <Icon className="h-3.5 w-3.5" />}
+                </div>
+                <span className="hidden sm:inline">{step.label}</span>
+              </button>
+              {index < steps.length - 1 && (
+                <ChevronRight className="h-4 w-4 text-border flex-shrink-0" />
+              )}
+            </React.Fragment>
+          );
+        })}
+      </nav>
+    </div>
+  );
+};
+
+const SearchResultItem = ({ item, isSelected, onSelect }) => (
+  <button
+    type="button"
+    onClick={onSelect}
+    className={`
+      relative w-full text-left rounded-lg border-2 p-3 transition-all duration-200 cursor-pointer
+      ${isSelected
+        ? "border-primary bg-accent shadow-sm glow-sm"
+        : "border-border/50 hover:border-border hover:bg-accent/50"
+      }
+    `}
+  >
+    {isSelected && (
+      <motion.div
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary shadow-sm"
+      >
+        <Check className="h-3 w-3 text-primary-foreground" strokeWidth={3} />
+      </motion.div>
+    )}
+    <div className="font-semibold text-sm truncate">{item.tag}</div>
+    {item.description && (
+      <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{item.description}</p>
+    )}
+    <div className="flex items-center gap-3 mt-2">
+      {item.version && (
+        <span className="text-[10px] font-mono text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+          v{item.version}
+        </span>
+      )}
+      {item.downloads != null && (
+        <span className="text-[10px] text-muted-foreground">
+          {item.downloads.toLocaleString()} downloads
+        </span>
+      )}
+    </div>
+  </button>
 );
 
 const TerminalPreview = ({ config, downloadLink, generated, onEditorChange }) => {
@@ -101,8 +169,8 @@ const TerminalPreview = ({ config, downloadLink, generated, onEditorChange }) =>
 
   if (!generated) {
     return (
-      <div className="rounded-xl border border-dashed border-border/60 bg-card">
-        <div className="flex flex-col items-center justify-center py-20 text-center px-6">
+      <div className="rounded-xl border border-dashed border-border/60 bg-card" style={{ minHeight: STEP_CONTAINER_HEIGHT }}>
+        <div className="flex flex-col items-center justify-center h-full py-20 text-center px-6">
           <div className="rounded-2xl bg-accent/50 p-5 mb-5">
             <Terminal className="h-10 w-10 text-muted-foreground/60" />
           </div>
@@ -214,6 +282,7 @@ const stepVariants = {
 
 const VagrantConfigGenerator = () => {
   const [activeStep, setActiveStep] = useState(0);
+  const [searchMode, setSearchMode] = useState(false);
   const {
     formData,
     config,
@@ -225,6 +294,8 @@ const VagrantConfigGenerator = () => {
     handleFinish,
     onEditorChange,
   } = useVagrantConfig();
+
+  const { query, setQuery, results, loading, error } = useVagrantCloudSearch();
 
   const isLastStep = activeStep === STEPS.length - 1;
 
@@ -240,6 +311,12 @@ const VagrantConfigGenerator = () => {
 
   const handleGenerate = (e) => {
     handleFinish(e);
+  };
+
+  const handleSearchSelect = (box) => {
+    handleInputChange({ target: { name: "box", value: box.tag } });
+    setSearchMode(false);
+    setQuery("");
   };
 
   return (
@@ -271,221 +348,297 @@ const VagrantConfigGenerator = () => {
               steps={STEPS}
               activeStep={activeStep}
               onStepClick={setActiveStep}
-              generated={generated}
             />
 
             <form onSubmit={handleGenerate}>
-              <AnimatePresence mode="wait">
-                {/* Step 0: OS Selection */}
-                {activeStep === 0 && (
-                  <motion.div key="step-os" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
-                    <Card>
-                      <CardHeader>
-                        <div className="flex items-center gap-3">
-                          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
-                            <Monitor className="h-4.5 w-4.5 text-primary" />
+              {/* Fixed-height container to prevent layout jumps */}
+              <div style={{ minHeight: STEP_CONTAINER_HEIGHT }} className="relative">
+                <AnimatePresence mode="wait">
+                  {/* Step 0: OS Selection */}
+                  {activeStep === 0 && (
+                    <motion.div key="step-os" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
+                      <Card className="flex flex-col" style={{ height: STEP_CONTAINER_HEIGHT }}>
+                        <CardHeader className="flex-shrink-0">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-3">
+                              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                                <Monitor className="h-4.5 w-4.5 text-primary" />
+                              </div>
+                              <div>
+                                <CardTitle className="text-lg">Operating System</CardTitle>
+                                <CardDescription>
+                                  Choose a base box or search Vagrant Cloud.
+                                </CardDescription>
+                              </div>
+                            </div>
+                            <Button
+                              type="button"
+                              variant={searchMode ? "default" : "outline"}
+                              size="sm"
+                              onClick={() => { setSearchMode(!searchMode); setQuery(""); }}
+                              className="flex-shrink-0"
+                            >
+                              {searchMode ? (
+                                <>
+                                  <Monitor className="h-3.5 w-3.5 mr-1.5" />
+                                  Quick Start
+                                </>
+                              ) : (
+                                <>
+                                  <Cloud className="h-3.5 w-3.5 mr-1.5" />
+                                  Search Cloud
+                                </>
+                              )}
+                            </Button>
                           </div>
-                          <div>
-                            <CardTitle className="text-lg">Operating System</CardTitle>
-                            <CardDescription>
-                              Choose a base box or{" "}
-                              <a
-                                target="_blank"
-                                rel="noreferrer"
-                                href="https://app.vagrantup.com/boxes/search"
-                                className="font-medium text-primary hover:text-primary/80 transition-colors"
-                              >
-                                search Vagrant Cloud
-                                <ExternalLink className="ml-1 inline h-3 w-3" />
-                              </a>
-                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="flex-1 overflow-y-auto space-y-5">
+                          <TextInput
+                            handleInputChange={handleInputChange}
+                            formData={formData.box}
+                            name="Box Image"
+                            value="box"
+                            holder="e.g. ubuntu/jammy64"
+                          />
+
+                          {searchMode ? (
+                            <div className="space-y-4">
+                              {/* Search Input */}
+                              <div className="relative">
+                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                                <Input
+                                  type="text"
+                                  value={query}
+                                  onChange={(e) => setQuery(e.target.value)}
+                                  placeholder="Search Vagrant Cloud (e.g. ubuntu, alpine, windows)..."
+                                  className="pl-9 pr-9"
+                                  autoFocus
+                                />
+                                {loading && (
+                                  <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground animate-spin" />
+                                )}
+                              </div>
+
+                              {/* Search Results */}
+                              {error && (
+                                <p className="text-sm text-destructive text-center py-4">{error}</p>
+                              )}
+
+                              {!query && !loading && (
+                                <div className="flex flex-col items-center justify-center py-8 text-center">
+                                  <Cloud className="h-8 w-8 text-muted-foreground/40 mb-3" />
+                                  <p className="text-sm text-muted-foreground">
+                                    Type to search thousands of boxes on Vagrant Cloud
+                                  </p>
+                                </div>
+                              )}
+
+                              {query && !loading && results.length === 0 && !error && (
+                                <div className="flex flex-col items-center justify-center py-8 text-center">
+                                  <Search className="h-8 w-8 text-muted-foreground/40 mb-3" />
+                                  <p className="text-sm text-muted-foreground">
+                                    No boxes found for "{query}"
+                                  </p>
+                                </div>
+                              )}
+
+                              {results.length > 0 && (
+                                <div className="grid gap-2 grid-cols-1 sm:grid-cols-2">
+                                  {results.map((box) => (
+                                    <SearchResultItem
+                                      key={box.id}
+                                      item={box}
+                                      isSelected={formData.box === box.tag}
+                                      onSelect={() => handleSearchSelect(box)}
+                                    />
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          ) : (
+                            <div className="space-y-4">
+                              <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                Quick Start
+                              </Label>
+                              <ul className="grid w-full gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+                                {boxes.map((box) => (
+                                  <RadioCard
+                                    key={box.id}
+                                    item={box}
+                                    value="box"
+                                    handleInputChange={handleInputChange}
+                                    formData={formData.box}
+                                  />
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                        </CardContent>
+                      </Card>
+                    </motion.div>
+                  )}
+
+                  {/* Step 1: Provider */}
+                  {activeStep === 1 && (
+                    <motion.div key="step-provider" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
+                      <Card className="flex flex-col" style={{ height: STEP_CONTAINER_HEIGHT }}>
+                        <CardHeader className="flex-shrink-0">
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                              <Server className="h-4.5 w-4.5 text-primary" />
+                            </div>
+                            <div>
+                              <CardTitle className="text-lg">Virtualization Provider</CardTitle>
+                              <CardDescription>
+                                Select the backend that powers your virtual machines.
+                              </CardDescription>
+                            </div>
                           </div>
-                        </div>
-                      </CardHeader>
-                      <CardContent className="space-y-5">
-                        <TextInput
-                          handleInputChange={handleInputChange}
-                          formData={formData.box}
-                          name="Box Image"
-                          value="box"
-                          holder="e.g. ubuntu/jammy64"
-                        />
-                        <ul className="grid w-full gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
-                          {boxes.map((box) => (
-                            <RadioCard
-                              key={box.id}
-                              item={box}
-                              value="box"
+                        </CardHeader>
+                        <CardContent className="flex-1 overflow-y-auto">
+                          <ProviderSelect
+                            formData={formData}
+                            handleInputChange={handleInputChange}
+                            handleGroupChange={handleGroupChange}
+                            selectedGroup={selectedGroup}
+                          />
+                        </CardContent>
+                      </Card>
+                    </motion.div>
+                  )}
+
+                  {/* Step 2: Resources */}
+                  {activeStep === 2 && (
+                    <motion.div key="step-resources" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
+                      <Card className="flex flex-col" style={{ height: STEP_CONTAINER_HEIGHT }}>
+                        <CardHeader className="flex-shrink-0">
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                              <Cpu className="h-4.5 w-4.5 text-primary" />
+                            </div>
+                            <div>
+                              <CardTitle className="text-lg">Resources</CardTitle>
+                              <CardDescription>
+                                Allocate compute, memory, and storage for your VM.
+                              </CardDescription>
+                            </div>
+                          </div>
+                        </CardHeader>
+                        <CardContent className="flex-1 overflow-y-auto space-y-6">
+                          <div className="space-y-3">
+                            <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">CPUs</Label>
+                            <ul className="grid w-full gap-2.5 grid-cols-4 md:grid-cols-8">
+                              {cpuOptions.map((cpuOption) => (
+                                <RadioCard
+                                  key={cpuOption.id}
+                                  item={cpuOption}
+                                  value="cpus"
+                                  handleInputChange={handleInputChange}
+                                  formData={formData.cpus}
+                                />
+                              ))}
+                            </ul>
+                          </div>
+
+                          <div className="h-px bg-border/50" />
+
+                          <div className="space-y-3">
+                            <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Memory</Label>
+                            <ul className="grid w-full gap-2.5 grid-cols-2 md:grid-cols-4">
+                              {memoryOptions.map((memoryOption) => (
+                                <RadioCard
+                                  key={memoryOption.id}
+                                  item={memoryOption}
+                                  value="memory"
+                                  handleInputChange={handleInputChange}
+                                  formData={formData.memory}
+                                />
+                              ))}
+                            </ul>
+                          </div>
+
+                          <div className="h-px bg-border/50" />
+
+                          <TextInput
+                            handleInputChange={handleInputChange}
+                            formData={formData.disk_size}
+                            name="Disk Size"
+                            value="disk_size"
+                            holder="e.g. 20GB"
+                          />
+                        </CardContent>
+                      </Card>
+                    </motion.div>
+                  )}
+
+                  {/* Step 3: Network & Identity */}
+                  {activeStep === 3 && (
+                    <motion.div key="step-network" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
+                      <Card className="flex flex-col" style={{ height: STEP_CONTAINER_HEIGHT }}>
+                        <CardHeader className="flex-shrink-0">
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                              <Network className="h-4.5 w-4.5 text-primary" />
+                            </div>
+                            <div>
+                              <CardTitle className="text-lg">Network & Identity</CardTitle>
+                              <CardDescription>
+                                Configure machine identity, networking, and scaling.
+                              </CardDescription>
+                            </div>
+                          </div>
+                        </CardHeader>
+                        <CardContent className="flex-1 overflow-y-auto space-y-5">
+                          <div className="grid gap-4 sm:grid-cols-2">
+                            <TextInput
                               handleInputChange={handleInputChange}
-                              formData={formData.box}
+                              formData={formData.name}
+                              name="Machine Name"
+                              value="name"
+                              holder="e.g. webserver"
                             />
-                          ))}
-                        </ul>
-                      </CardContent>
-                    </Card>
-                  </motion.div>
-                )}
-
-                {/* Step 1: Provider */}
-                {activeStep === 1 && (
-                  <motion.div key="step-provider" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
-                    <Card>
-                      <CardHeader>
-                        <div className="flex items-center gap-3">
-                          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
-                            <Server className="h-4.5 w-4.5 text-primary" />
+                            <TextInput
+                              handleInputChange={handleInputChange}
+                              formData={formData.hostname}
+                              name="Host Name"
+                              value="hostname"
+                              holder="e.g. webserver.local"
+                            />
                           </div>
-                          <div>
-                            <CardTitle className="text-lg">Virtualization Provider</CardTitle>
-                            <CardDescription>
-                              Select the backend that powers your virtual machines.
-                            </CardDescription>
+                          <div className="grid gap-4 sm:grid-cols-2">
+                            <TextInput
+                              handleInputChange={handleInputChange}
+                              formData={formData.ip}
+                              name="IP Address"
+                              value="ip"
+                              holder="e.g. 192.168.33.10"
+                            />
+                            <TextInput
+                              handleInputChange={handleInputChange}
+                              formData={formData.count}
+                              name="Instance Count"
+                              value="count"
+                              holder="1"
+                              type="number"
+                            />
                           </div>
-                        </div>
-                      </CardHeader>
-                      <CardContent>
-                        <ProviderSelect
-                          formData={formData}
-                          handleInputChange={handleInputChange}
-                          handleGroupChange={handleGroupChange}
-                          selectedGroup={selectedGroup}
-                        />
-                      </CardContent>
-                    </Card>
-                  </motion.div>
-                )}
-
-                {/* Step 2: Resources */}
-                {activeStep === 2 && (
-                  <motion.div key="step-resources" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
-                    <Card>
-                      <CardHeader>
-                        <div className="flex items-center gap-3">
-                          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
-                            <Cpu className="h-4.5 w-4.5 text-primary" />
+                          <div className="flex items-center space-x-2.5 pt-1">
+                            <Checkbox
+                              id="iterationStartFrom0"
+                              name="iterationStartFrom0"
+                              checked={formData.iterationStartFrom0}
+                              onChange={handleInputChange}
+                            />
+                            <Label htmlFor="iterationStartFrom0" className="cursor-pointer text-sm">
+                              Start iteration from 0
+                            </Label>
                           </div>
-                          <div>
-                            <CardTitle className="text-lg">Resources</CardTitle>
-                            <CardDescription>
-                              Allocate compute, memory, and storage for your VM.
-                            </CardDescription>
-                          </div>
-                        </div>
-                      </CardHeader>
-                      <CardContent className="space-y-6">
-                        <div className="space-y-3">
-                          <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">CPUs</Label>
-                          <ul className="grid w-full gap-2.5 grid-cols-4 md:grid-cols-8">
-                            {cpuOptions.map((cpuOption) => (
-                              <RadioCard
-                                key={cpuOption.id}
-                                item={cpuOption}
-                                value="cpus"
-                                handleInputChange={handleInputChange}
-                                formData={formData.cpus}
-                              />
-                            ))}
-                          </ul>
-                        </div>
-
-                        <div className="h-px bg-border/50" />
-
-                        <div className="space-y-3">
-                          <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Memory</Label>
-                          <ul className="grid w-full gap-2.5 grid-cols-2 md:grid-cols-4">
-                            {memoryOptions.map((memoryOption) => (
-                              <RadioCard
-                                key={memoryOption.id}
-                                item={memoryOption}
-                                value="memory"
-                                handleInputChange={handleInputChange}
-                                formData={formData.memory}
-                              />
-                            ))}
-                          </ul>
-                        </div>
-
-                        <div className="h-px bg-border/50" />
-
-                        <TextInput
-                          handleInputChange={handleInputChange}
-                          formData={formData.disk_size}
-                          name="Disk Size"
-                          value="disk_size"
-                          holder="e.g. 20GB"
-                        />
-                      </CardContent>
-                    </Card>
-                  </motion.div>
-                )}
-
-                {/* Step 3: Network & Identity */}
-                {activeStep === 3 && (
-                  <motion.div key="step-network" variants={stepVariants} initial="hidden" animate="visible" exit="exit">
-                    <Card>
-                      <CardHeader>
-                        <div className="flex items-center gap-3">
-                          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
-                            <Network className="h-4.5 w-4.5 text-primary" />
-                          </div>
-                          <div>
-                            <CardTitle className="text-lg">Network & Identity</CardTitle>
-                            <CardDescription>
-                              Configure machine identity, networking, and scaling.
-                            </CardDescription>
-                          </div>
-                        </div>
-                      </CardHeader>
-                      <CardContent className="space-y-5">
-                        <div className="grid gap-4 sm:grid-cols-2">
-                          <TextInput
-                            handleInputChange={handleInputChange}
-                            formData={formData.name}
-                            name="Machine Name"
-                            value="name"
-                            holder="e.g. webserver"
-                          />
-                          <TextInput
-                            handleInputChange={handleInputChange}
-                            formData={formData.hostname}
-                            name="Host Name"
-                            value="hostname"
-                            holder="e.g. webserver.local"
-                          />
-                        </div>
-                        <div className="grid gap-4 sm:grid-cols-2">
-                          <TextInput
-                            handleInputChange={handleInputChange}
-                            formData={formData.ip}
-                            name="IP Address"
-                            value="ip"
-                            holder="e.g. 192.168.33.10"
-                          />
-                          <TextInput
-                            handleInputChange={handleInputChange}
-                            formData={formData.count}
-                            name="Instance Count"
-                            value="count"
-                            holder="1"
-                            type="number"
-                          />
-                        </div>
-                        <div className="flex items-center space-x-2.5 pt-1">
-                          <Checkbox
-                            id="iterationStartFrom0"
-                            name="iterationStartFrom0"
-                            checked={formData.iterationStartFrom0}
-                            onChange={handleInputChange}
-                          />
-                          <Label htmlFor="iterationStartFrom0" className="cursor-pointer text-sm">
-                            Start iteration from 0
-                          </Label>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  </motion.div>
-                )}
-              </AnimatePresence>
+                        </CardContent>
+                      </Card>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
 
               {/* Navigation Buttons */}
               <div className="flex items-center justify-between mt-6">

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { cva } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Badge({ className, variant, ...props }) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { cva } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+const Button = React.forwardRef(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -3,24 +3,26 @@ import { cva } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.98]",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-accent-foreground/20",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        glow: "bg-primary text-primary-foreground shadow-sm hover:shadow-lg glow-sm hover:glow-md",
       },
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        lg: "h-11 rounded-lg px-8",
         icon: "h-10 w-10",
       },
     },

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Card = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -5,7 +5,7 @@ const Card = React.forwardRef(({ className, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-xl border bg-card text-card-foreground shadow-sm transition-all duration-200 hover:shadow-md",
       className
     )}
     {...props}

--- a/src/components/ui/checkbox.jsx
+++ b/src/components/ui/checkbox.jsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Checkbox = React.forwardRef(({ className, ...props }, ref) => {
+  return (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={cn(
+        "h-4 w-4 shrink-0 rounded border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 accent-primary",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+Checkbox.displayName = "Checkbox";
+
+export { Checkbox };

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Input = React.forwardRef(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -6,7 +6,7 @@ const Input = React.forwardRef(({ className, type, ...props }, ref) => {
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:border-primary/50 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/src/components/ui/label.jsx
+++ b/src/components/ui/label.jsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { cva } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+);
+
+const Label = React.forwardRef(({ className, ...props }, ref) => (
+  <label ref={ref} className={cn(labelVariants(), className)} {...props} />
+));
+Label.displayName = "Label";
+
+export { Label };

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Select = React.forwardRef(({ className, children, ...props }, ref) => {
+  return (
+    <select
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </select>
+  );
+});
+Select.displayName = "Select";
+
+export { Select };

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -6,7 +6,7 @@ const Select = React.forwardRef(({ className, children, ...props }, ref) => {
     <select
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:border-primary/50 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/separator.jsx
+++ b/src/components/ui/separator.jsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Separator = React.forwardRef(
+  ({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+    <div
+      ref={ref}
+      role={decorative ? "none" : "separator"}
+      aria-orientation={!decorative ? orientation : undefined}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Separator.displayName = "Separator";
+
+export { Separator };

--- a/src/hooks/useVagrantCloudSearch.js
+++ b/src/hooks/useVagrantCloudSearch.js
@@ -1,0 +1,66 @@
+import { useState, useEffect, useRef } from "react";
+
+const VAGRANT_CLOUD_API = "https://app.vagrantup.com/api/v2/search";
+
+export function useVagrantCloudSearch() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const abortRef = useRef(null);
+  const debounceRef = useRef(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (!query.trim()) {
+      setResults([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    debounceRef.current = setTimeout(async () => {
+      if (abortRef.current) abortRef.current.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const res = await fetch(
+          `${VAGRANT_CLOUD_API}?q=${encodeURIComponent(query.trim())}&limit=12`,
+          { signal: controller.signal }
+        );
+        if (!res.ok) throw new Error("Failed to fetch boxes");
+        const data = await res.json();
+        const boxes = (data.boxes || []).map((box) => ({
+          id: box.tag,
+          value: box.tag,
+          name: box.name,
+          tag: box.tag,
+          description: box.short_description || box.description_short || "",
+          downloads: box.downloads,
+          provider: box.current_version?.providers?.[0]?.name || "",
+          version: box.current_version?.version || "",
+        }));
+        setResults(boxes);
+      } catch (err) {
+        if (err.name !== "AbortError") {
+          setError("Search failed. Try again.");
+          setResults([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }, 350);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, [query]);
+
+  return { query, setQuery, results, loading, error };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,22 +4,56 @@
 
 @layer base {
   :root {
-    --color-bg-primary: #ffffff;
-    --color-bg-secondary: #f9fafb;
-    --color-text-primary: #111827;
-    --color-text-secondary: #374151;
-    --color-border: #e5e7eb;
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 5.9% 10%;
+    --radius: 0.5rem;
   }
 
   .dark {
-    --color-bg-primary: #111827;
-    --color-bg-secondary: #1f2937;
-    --color-text-primary: #f9fafb;
-    --color-text-secondary: #d1d5db;
-    --color-border: #374151;
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
   }
+}
 
+@layer base {
+  * {
+    @apply border-border;
+  }
   body {
-    @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-200;
+    @apply bg-background text-foreground;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -99,4 +99,19 @@
   .dark .terminal-bg {
     background: linear-gradient(180deg, hsl(222 47% 4%) 0%, hsl(222 47% 2.5%) 100%);
   }
+
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,48 +4,56 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
+    --background: 0 0% 99%;
+    --foreground: 222 47% 11%;
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 222 47% 11%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
+    --popover-foreground: 222 47% 11%;
+    --primary: 234 89% 63%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 220 14% 96%;
+    --secondary-foreground: 222 47% 11%;
+    --muted: 220 14% 96%;
+    --muted-foreground: 220 9% 46%;
+    --accent: 234 89% 96%;
+    --accent-foreground: 234 89% 53%;
+    --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 5.9% 10%;
-    --radius: 0.5rem;
+    --border: 220 13% 91%;
+    --input: 220 13% 91%;
+    --ring: 234 89% 63%;
+    --radius: 0.625rem;
+
+    --glow: 234 89% 63%;
+    --surface: 220 14% 98%;
+    --surface-hover: 220 14% 95%;
   }
 
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
+    --background: 222 47% 5%;
+    --foreground: 210 40% 96%;
+    --card: 222 41% 8%;
+    --card-foreground: 210 40% 96%;
+    --popover: 222 41% 8%;
+    --popover-foreground: 210 40% 96%;
+    --primary: 234 89% 63%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 222 41% 12%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 222 41% 12%;
+    --muted-foreground: 218 11% 55%;
+    --accent: 234 50% 15%;
+    --accent-foreground: 234 89% 74%;
+    --destructive: 0 63% 31%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --border: 222 41% 14%;
+    --input: 222 41% 14%;
+    --ring: 234 89% 63%;
+
+    --glow: 234 89% 63%;
+    --surface: 222 41% 7%;
+    --surface-hover: 222 41% 10%;
   }
 }
 
@@ -54,6 +62,41 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+  }
+}
+
+@layer utilities {
+  .glow-sm {
+    box-shadow: 0 0 15px -3px hsl(var(--glow) / 0.15);
+  }
+  .glow-md {
+    box-shadow: 0 0 25px -5px hsl(var(--glow) / 0.2);
+  }
+  .glow-lg {
+    box-shadow: 0 0 40px -8px hsl(var(--glow) / 0.25);
+  }
+
+  .glass {
+    @apply bg-card/80 backdrop-blur-xl;
+    border: 1px solid hsl(var(--border) / 0.5);
+  }
+
+  .glass-strong {
+    @apply bg-card/90 backdrop-blur-2xl;
+    border: 1px solid hsl(var(--border) / 0.6);
+  }
+
+  .gradient-text {
+    @apply bg-clip-text text-transparent;
+    background-image: linear-gradient(135deg, hsl(234 89% 63%) 0%, hsl(280 80% 65%) 100%);
+  }
+
+  .terminal-bg {
+    background: linear-gradient(180deg, hsl(222 47% 6%) 0%, hsl(222 47% 4%) 100%);
+  }
+
+  .dark .terminal-bg {
+    background: linear-gradient(180deg, hsl(222 47% 4%) 0%, hsl(222 47% 2.5%) 100%);
   }
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,11 +1,79 @@
+const { fontFamily } = require("tailwindcss/defaultTheme");
+
 /** @type {import('tailwindcss').Config} */
-const colors = require("tailwindcss/colors");
 module.exports = {
-  darkMode: "class",
+  darkMode: ["class"],
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
-    "node_modules/flowbite-react/**/*.{js,jsx,ts,tsx}",
-    "./Components/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
   ],
-  plugins: [require("flowbite/plugin")],
+  theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      fontFamily: {
+        sans: ["Inter", ...fontFamily.sans],
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [require("tailwindcss-animate")],
 };

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,6 +22,10 @@ module.exports = {
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        surface: {
+          DEFAULT: "hsl(var(--surface))",
+          hover: "hsl(var(--surface-hover))",
+        },
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
@@ -52,12 +56,14 @@ module.exports = {
         },
       },
       borderRadius: {
+        xl: "calc(var(--radius) + 4px)",
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
         sans: ["Inter", ...fontFamily.sans],
+        mono: ["JetBrains Mono", "Fira Code", "monospace"],
       },
       keyframes: {
         "accordion-down": {
@@ -68,10 +74,30 @@ module.exports = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "fade-in": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        "slide-in-right": {
+          from: { opacity: "0", transform: "translateX(12px)" },
+          to: { opacity: "1", transform: "translateX(0)" },
+        },
+        "scale-in": {
+          from: { opacity: "0", transform: "scale(0.95)" },
+          to: { opacity: "1", transform: "scale(1)" },
+        },
+        shimmer: {
+          "0%": { backgroundPosition: "-200% 0" },
+          "100%": { backgroundPosition: "200% 0" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "fade-in": "fade-in 0.3s ease-out",
+        "slide-in-right": "slide-in-right 0.3s ease-out",
+        "scale-in": "scale-in 0.2s ease-out",
+        shimmer: "shimmer 2s linear infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Replaced Flowbite with **shadcn/ui** component system (Card, Button, Input, Label, Select, Checkbox, Separator, Badge)
- Implemented **dark-first aesthetic** using CSS variable theming (zinc palette) with light/dark mode toggle preserved
- Redesigned layout with **card-based sections** (Operating System, Provider, Resources, Network & Identity) and a **sticky two-column preview panel**
- Added lucide-react icons throughout (Play, Download, ExternalLink, Github, Sun/Moon)
- Switched code editor theme from Monokai to One Dark for better visual cohesion
- Added Inter font via Google Fonts for typography consistency
- Removed flowbite/flowbite-react dependencies, replaced with tailwindcss-animate, class-variance-authority, clsx, tailwind-merge, lucide-react

## Test plan
- [ ] Verify dark mode toggle works and persists across page reloads
- [ ] Verify all OS box selections work correctly
- [ ] Verify provider group/dropdown filtering and radio card selection
- [ ] Verify CPU and memory selections update config
- [ ] Verify text inputs (disk size, machine name, hostname, IP, count) work
- [ ] Verify "Start iteration from 0" checkbox works
- [ ] Verify "Generate Vagrantfile" button produces correct preview
- [ ] Verify code editor is editable and Download button saves correct file
- [ ] Verify mobile responsiveness at various breakpoints
- [ ] Verify production build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)